### PR TITLE
feat: add encoding detection for parsed files

### DIFF
--- a/apps/game/src-tauri/Cargo.lock
+++ b/apps/game/src-tauri/Cargo.lock
@@ -719,6 +719,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chardetng"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14b8f0b65b7b08ae3c8187e8d77174de20cb6777864c6b832d8ad365999cf1ea"
+dependencies = [
+ "cfg-if",
+ "encoding_rs",
+ "memchr",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5443,9 +5454,11 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 name = "tuneperfect_game"
 version = "0.0.33"
 dependencies = [
+ "chardetng",
  "cpal",
  "dunce",
  "dywapitchtrack",
+ "encoding_rs",
  "http",
  "http-range",
  "lofty",

--- a/apps/game/src-tauri/Cargo.toml
+++ b/apps/game/src-tauri/Cargo.toml
@@ -51,6 +51,8 @@ walkdir = "2"
 dunce = "1.0.5"
 urlencoding = "2.1.3"
 unicode-normalization = "0.1"
+encoding_rs = "0.8"
+chardetng = "0.1"
 num_cpus = "1.16"
 semver = "1.0"
 

--- a/apps/game/src-tauri/src/ultrastar/parser.rs
+++ b/apps/game/src-tauri/src/ultrastar/parser.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use chardetng::EncodingDetector;
 use unicode_normalization::UnicodeNormalization;
 use semver::Version;
 
@@ -294,7 +295,12 @@ pub fn parse_local_txt_file(
     files: &Vec<FileEntry>,
     media_base_url: &str,
 ) -> Result<LocalSong, AppError> {
-    let content = fs::read_to_string(txt)?;
+    let bytes = fs::read(txt)?;
+    let mut detector = EncodingDetector::new();
+    detector.feed(&bytes, true);
+    let encoding = detector.guess(None, true);
+    let (content, _, _) = encoding.decode(&bytes);
+
     let song = parse_ultrastar_txt(&content)?;
 
     let find_file = |filename: &Option<String>| -> Option<&FileEntry> {


### PR DESCRIPTION
This uses chardetng to detect the encoding of txt files which are not encoded in UTF-8 and then loads them properly.

It fixes #55 