### PR TITLE
feat(song-select): add decade, duet and solo filters

### DIFF
--- a/apps/game/src/components/song-select/search-button.tsx
+++ b/apps/game/src/components/song-select/search-button.tsx
@@ -23,6 +23,9 @@ const FILTER_LABELS: Record<SearchFilter, () => string> = {
   language: () => t("sing.filter.language"),
   edition: () => t("sing.filter.edition"),
   creator: () => t("sing.filter.creator"),
+  decade: () => t("sing.filter.decade"),
+  duet: () => t("sing.filter.duet"),
+  solo: () => t("sing.filter.solo"),
 };
 
 export function SearchButton(props: SearchButtonProps) {

--- a/apps/game/src/components/song-select/search-popup.tsx
+++ b/apps/game/src/components/song-select/search-popup.tsx
@@ -21,20 +21,28 @@ interface SearchPopupProps {
   onClose: () => void;
 }
 
+// Filters that don't require a text query
+export const QUERY_FREE_FILTERS: SearchFilter[] = ["duet", "solo"];
+
 const FILTER_OPTIONS: { value: SearchFilter; label: () => string }[] = [
   { value: "all", label: () => t("sing.filter.all") },
   { value: "artist", label: () => t("sing.sort.artist") },
   { value: "title", label: () => t("sing.sort.title") },
   { value: "year", label: () => t("sing.sort.year") },
+  { value: "decade", label: () => t("sing.filter.decade") },
   { value: "genre", label: () => t("sing.filter.genre") },
   { value: "language", label: () => t("sing.filter.language") },
   { value: "edition", label: () => t("sing.filter.edition") },
   { value: "creator", label: () => t("sing.filter.creator") },
+  { value: "duet", label: () => t("sing.filter.duet") },
+  { value: "solo", label: () => t("sing.filter.solo") },
 ];
 
 export function SearchPopup(props: SearchPopupProps) {
-  let searchRef!: HTMLInputElement;
+  let searchRef: HTMLInputElement | undefined;
   let popupRef!: HTMLDivElement;
+
+  const isQueryFree = () => QUERY_FREE_FILTERS.includes(props.searchFilter);
 
   createEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -84,7 +92,7 @@ export function SearchPopup(props: SearchPopupProps) {
   });
 
   onMount(() => {
-    searchRef.focus();
+    searchRef?.focus();
   });
 
   const currentFilterLabel = () =>
@@ -133,14 +141,26 @@ export function SearchPopup(props: SearchPopupProps) {
             </div>
           </div>
 
-          <input
-            value={props.searchQuery}
-            onInput={onInput}
-            ref={searchRef}
-            type="text"
-            placeholder={t("sing.search")}
-            class="focus:gradient-sing placeholder-gray-400 w-full rounded-md bg-white/10 px-3 py-2 text-white transition-all focus:bg-linear-to-r focus:outline-none"
-          />
+          <Show
+            when={!isQueryFree()}
+            fallback={
+              <div class="flex items-center justify-center gap-2 rounded-md bg-white/10 px-3 py-2 text-sm text-white/70">
+                <span>
+                  {currentFilterLabel()}
+                </span>
+                <span class="text-white/40">— {t("sing.filter.active")}</span>
+              </div>
+            }
+          >
+            <input
+              value={props.searchQuery}
+              onInput={onInput}
+              ref={searchRef}
+              type="text"
+              placeholder={t("sing.search")}
+              class="focus:gradient-sing placeholder-gray-400 w-full rounded-md bg-white/10 px-3 py-2 text-white transition-all focus:bg-linear-to-r focus:outline-none"
+            />
+          </Show>
         </div>
 
         <Show when={keyMode() === "gamepad"}>

--- a/apps/game/src/hooks/use-song-filter.ts
+++ b/apps/game/src/hooks/use-song-filter.ts
@@ -5,7 +5,7 @@ import { type Accessor, createEffect, createMemo, createSignal } from "solid-js"
 import type { LocalSong } from "~/lib/ultrastar/song";
 
 export type SortOption = "artist" | "title" | "year";
-export type SearchFilter = "all" | "artist" | "title" | "year" | "genre" | "language" | "edition" | "creator";
+export type SearchFilter = "all" | "artist" | "title" | "year" | "genre" | "language" | "edition" | "creator" | "decade" | "duet" | "solo";
 
 const ALL_SEARCH_FIELDS = ["title", "artist", "genre", "language", "edition", "creator"] as const;
 
@@ -71,11 +71,24 @@ export function useSongFilter(options: UseSongFilterOptions): UseSongFilterResul
   const filteredItems = createMemo(() => {
     let songs = options.items();
     const query = debouncedSearchQuery().trim();
+    const filter = options.searchFilter();
 
-    if (query) {
-      const filter = options.searchFilter();
-
-      if (filter === "year") {
+    // Duet/solo filters apply independently of search query
+    if (filter === "duet") {
+      songs = songs.filter((song) => song.p2 !== null);
+    } else if (filter === "solo") {
+      songs = songs.filter((song) => song.p2 === null);
+    } else if (query) {
+      if (filter === "decade") {
+        const decadeQuery = Number.parseInt(query, 10);
+        if (!Number.isNaN(decadeQuery)) {
+          // Support both "80" and "1980" as input
+          const decade = decadeQuery < 100 ? decadeQuery * 10 : Math.floor(decadeQuery / 10) * 10;
+          songs = songs.filter((song) => song.year !== null && Math.floor(song.year / 10) * 10 === decade);
+        } else {
+          songs = [];
+        }
+      } else if (filter === "year") {
         const yearQuery = Number.parseInt(query, 10);
         if (!Number.isNaN(yearQuery)) {
           songs = songs.filter((song) => song.year === yearQuery);

--- a/apps/game/src/i18n/de.ts
+++ b/apps/game/src/i18n/de.ts
@@ -94,6 +94,10 @@ const de = {
       language: "Sprache",
       edition: "Edition",
       creator: "Ersteller",
+      decade: "Jahrzehnt",
+      duet: "Duette",
+      solo: "Solo",
+      active: "Filter aktiv",
     },
     sort: {
       artist: "Künstler",

--- a/apps/game/src/i18n/en.ts
+++ b/apps/game/src/i18n/en.ts
@@ -94,6 +94,10 @@ const en = {
       language: "Language",
       edition: "Edition",
       creator: "Creator",
+      decade: "Decade",
+      duet: "Duets",
+      solo: "Solo",
+      active: "filter active",
     },
     sort: {
       artist: "Artist",


### PR DESCRIPTION
Adds three new filter options to the song selector:

- **Duets** — shows only songs with a second voice (p2 !== null), no text input needed
- **Solo** — shows only songs without a second voice
- **Decade** — filter by decade, supports both "80" and "1980" as input

Changes:
- `use-song-filter.ts` — extended `SearchFilter` type and added filter logic
- `search-popup.tsx` — added new filter options, hides search input for duet/solo and shows an "filter active" indicator instead
- `search-button.tsx` — added missing labels for new filter types
- `en.ts` / `de.ts` — added translation keys for new filters

## Screenshots

<img width="576" height="228" alt="Screenshot 2026-04-25 170217" src="https://github.com/user-attachments/assets/a89b79da-7eed-4074-8aea-fc6232cfb6e0" />

<img width="537" height="225" alt="Screenshot 2026-04-25 170231" src="https://github.com/user-attachments/assets/f9e95421-d703-430d-9fa5-9619ab743b5c" />

<img width="532" height="209" alt="Screenshot 2026-04-25 170223" src="https://github.com/user-attachments/assets/e98e8452-011d-4489-832b-014a30c0d766" />